### PR TITLE
on logout, don't try to destroy already destroyed session

### DIFF
--- a/www/core/Auth/AuthManager.php
+++ b/www/core/Auth/AuthManager.php
@@ -262,7 +262,7 @@ class AuthManager extends Prefab {
         session_destroy();
         session_write_close();
         $this->f3->set('COOKIE.' . session_name(), '');
-        session_regenerate_id(true);
+        session_start();
 
         $this->assignUALoginState(true);
 


### PR DESCRIPTION
fixes PHP error

    session_regenerate_id(): Cannot regenerate session id - session is not active