### PR TITLE
Fix routing and cache issues on FatFree 3.6 migration

### DIFF
--- a/www/bootstrap.inc.php
+++ b/www/bootstrap.inc.php
@@ -107,7 +107,7 @@ if (preg_match('/^folder\h*=\h*(.+)/', $config['cache']) && substr($config['cach
 }
 $f3->set('CACHE', $config['cache']);
 $cache = \Cache::instance();
-$cache->reset(null, SIMPLEID_LONG_TOKEN_EXPIRES_IN);
+//$cache->reset(null, SIMPLEID_LONG_TOKEN_EXPIRES_IN);
 
 // 5. Logging
 if (!isset($config['logger']) || ($config['logger'] == '') || ($config['log_file'] == '')) {

--- a/www/bootstrap.inc.php
+++ b/www/bootstrap.inc.php
@@ -124,7 +124,7 @@ fix_http_request($f3);
 
 // For SimpleID 1.x compatibility
 if (isset($_GET['q'])) {
-    $f3->set('PATH', $_GET['q']);
+    $f3->set('PATH', '/' . $_GET['q']);
     unset($_GET['q']);
 }
 

--- a/www/core/Util/SecurityToken.php
+++ b/www/core/Util/SecurityToken.php
@@ -144,7 +144,8 @@ class SecurityToken {
 
         if (($options & self::OPTION_NONCE) == self::OPTION_NONCE) {
             $cache = \Cache::instance();
-            $cache->set($this->data['i'] . '.token', $token, SIMPLEID_HUMAN_TOKEN_EXPIRES_IN);
+            $cache_name = rawurlencode($this->data['i']) . '.token';
+            $cache->set($cache_name, $token, SIMPLEID_HUMAN_TOKEN_EXPIRES_IN);
         }
 
         return $token;


### PR DESCRIPTION
This fixes #36, which involves two issues in bootstrap.inc.php

- routes require a slash as its first character
- `Cache::reset` no longer supports $lifetime