### PR TITLE
Ensure correct type for $request param in OpenID Response constructor.

### DIFF
--- a/www/core/Protocols/OpenID/Response.php
+++ b/www/core/Protocols/OpenID/Response.php
@@ -57,14 +57,15 @@ class Response extends Message {
      * response will contain the same OpenID version, as well as the same
      * extension URI-to-alias mapping as the underlying request.
      * 
-     * @param Request $request the request to which the response will
+     * @param Request|array|null $request the request to which the response will
      * be made
      */
     public function __construct($request = NULL) {
-        if ($request != NULL) {
-            $this->setVersion($request->getVersion());
-            $this->extension_map = $request->getExtensionMap();
-        }
+        if ($request === null) return;
+        if (!$request instanceof Request) $request = new Request($request);
+
+        $this->setVersion($request->getVersion());
+        $this->extension_map = $request->getExtensionMap();
 
         foreach ($request as $key => $value) {
             if (strpos($key, 'openid.ns.') === 0) {


### PR DESCRIPTION
Error was:
> Call to a member function getVersion() on array
[core/Protocols/OpenID/Response.php:65]

I think, this way is easier and allows for more flexibility than to ensure callers wrap the request data correctly. On the other hand, moving forward and using typehints would be nice.