### PR TITLE
Fix OTP remember storage and retrieval

### DIFF
--- a/www/core/Auth/OTPAuthSchemeModule.php
+++ b/www/core/Auth/OTPAuthSchemeModule.php
@@ -239,6 +239,7 @@ class OTPAuthSchemeModule extends AuthSchemeModule {
             $store->saveUser($test_user); // Save the drift
 
             $event->addAuthModuleName(self::class);
+            $event->setUser($test_user);
             $event->setAuthLevel($form_state['mode']);
         }
     }

--- a/www/core/Auth/OTPAuthSchemeModule.php
+++ b/www/core/Auth/OTPAuthSchemeModule.php
@@ -188,7 +188,7 @@ class OTPAuthSchemeModule extends AuthSchemeModule {
             if ($test_user['otp']['type'] == 'recovery') return;
 
             $uaid = $auth->assignUAID();
-            if (isset($test_user->auth[$uaid]) && isset($test_user->auth[$uaid]['otp']) && $test_user->auth[$uaid]['otp']['remember']) return;
+            if (in_array($uaid, $test_user['otp']['remember'])) return;
 
             $tpl = new \Template();
 
@@ -256,11 +256,9 @@ class OTPAuthSchemeModule extends AuthSchemeModule {
 
         if (($level >= AuthManager::AUTH_LEVEL_VERIFIED) && isset($form_state['otp_remember']) && ($form_state['otp_remember'] == 1)) {
             $uaid = $auth->assignUAID();
-
-            if (!isset($user->auth[$uaid])) $user->auth[$uaid] = [];
-            if (!isset($user->auth[$uaid]['otp'])) $user->auth[$uaid]['otp'] = [];
-            
-            $user->auth[$uaid]['otp']['remember'] = true;
+            $remember = $user['otp']['remember'];
+            $remember[] = $uaid;
+            $user->pathSet('otp.remember', array_unique($remember));
 
             $store->saveUser($user);
         }


### PR DESCRIPTION
`OTPAuthSchemeModule` is saving user agents not requiring OTP verification ("remembered" browsers) under `$user->auth` (which was removed back in 010c8e5), instead of the correct `$user['otp']['remember']` array.