### PR TITLE
Fix incorrect serialisation of Response in FormState

### DIFF
--- a/www/core/Auth/AuthModule.php
+++ b/www/core/Auth/AuthModule.php
@@ -80,7 +80,7 @@ class AuthModule extends Module {
     public function login($f3, $params) {
         $dispatcher = \Events::instance();
 
-        $params['destination'] = (isset($params[1])) ? $params[1] : '';
+        $params['destination'] = (isset($params['*'])) ? $params['*'] : '';
         $this->f3->set('PARAMS.destination', $params['destination']);
 
         $token = new SecurityToken();
@@ -195,7 +195,7 @@ class AuthModule extends Module {
      * @param array $params
      */
     public function logout($f3, $params) {
-        $params['destination'] = (isset($params[1])) ? $params[1] : '';
+        $params['destination'] = (isset($params['*'])) ? $params['*'] : '';
         $this->f3->set('PARAMS.destination', $params['destination']);
 
         // Require HTTPS, redirect if necessary

--- a/www/core/Protocols/Connect/ConnectModule.php
+++ b/www/core/Protocols/Connect/ConnectModule.php
@@ -496,7 +496,7 @@ class ConnectModule extends OAuthProtectedResource implements ProtocolResult {
      *
      * @see ScopeInfoCollectionEvent
      */
-    public function scopesHook(ScopeInfoCollectionEvent $event) {
+    public function onScopeInfoCollectionEvent(ScopeInfoCollectionEvent $event) {
         $event->addScopeInfo('oauth', [
             'openid' => [
                 'description' => $this->f3->get('intl.common.scope.id'),

--- a/www/core/Protocols/Connect/ConnectModule.php
+++ b/www/core/Protocols/Connect/ConnectModule.php
@@ -542,7 +542,7 @@ class ConnectModule extends OAuthProtectedResource implements ProtocolResult {
         $jwt_encryption_enc_algs = AlgorithmFactory::getSupportedAlgs(Algorithm::ENCRYPTION_ALGORITHM);
 
         $claims_supported = [ 'sub', 'iss', 'auth_time', 'acr' ];
-        foreach ($scopes['oauth'] as $scope => $settings) {
+        foreach ($scopes as $scope => $settings) {
             if (isset($settings['claims'])) {
                 $claims_supporteds = array_merge($claims_supported, $settings['claims']);
             }

--- a/www/core/Protocols/OAuth/Response.php
+++ b/www/core/Protocols/OAuth/Response.php
@@ -66,11 +66,20 @@ class Response extends ArrayWrapper {
      * @param array $data the initial response parameters
      */
     public function __construct($request = NULL, $data = []) {
+        if (isset($data['#response_mode'])) {
+            $this->response_mode = $data['#response_mode'];
+            unset($data['#response_mode']);
+        }
+        if (isset($data['#redirect_uri'])) {
+            $this->redirect_uri = $data['#redirect_uri'];
+            unset($data['#redirect_uri']);
+        }
+
         parent::__construct($data);
 
         if ($request != NULL) {
             if (isset($request['state'])) $this->container['state'] = $request['state'];
-            if (isset($request['redirect_uri'])) $this->redirect_uri = $request['redirect_uri'];
+            if (isset($request['redirect_uri']) && ($this->redirect_uri == null)) $this->redirect_uri = $request['redirect_uri'];
         }
     }
 
@@ -231,6 +240,16 @@ class Response extends ArrayWrapper {
         $form = new FormResponse($this->container);
         if ($url == NULL) $url = $this->redirect_uri;
         $form->render($url);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray() {
+        $array = parent::toArray();
+        $array['#response_mode'] = $this->response_mode;
+        $array['#redirect_uri'] = $this->redirect_uri;
+        return $array;
     }
 
     /**

--- a/www/core/Protocols/OAuth/Response.php
+++ b/www/core/Protocols/OAuth/Response.php
@@ -165,6 +165,12 @@ class Response extends ArrayWrapper {
         $f3 = Base::instance();
 
         if ($redirect_uri == NULL) $redirect_uri = $this->redirect_uri;
+        // If $redirect_uri is still null we should output an error
+        if ($redirect_uri == NULL) {
+            $this->setError('server_error', 'Missing redirect_uri');
+            $this->renderJSON();
+            return;
+        }
 
         if ($this->response_mode == self::FORM_POST_RESPONSE_MODE) $this->renderFormPost($redirect_uri);
 

--- a/www/core/Util/Events/BaseDataCollectionEvent.php
+++ b/www/core/Util/Events/BaseDataCollectionEvent.php
@@ -94,7 +94,7 @@ class BaseDataCollectionEvent implements \GenericEventInterface {
             $merge_strategy = $this->mergeStrategy;
         }
 
-        switch ($this->mergeStrategy) {
+        switch ($merge_strategy) {
             case self::MERGE_APPEND:
                 $this->results[] = $result;
                 break;

--- a/www/core/Util/Forms/FormState.php
+++ b/www/core/Util/Forms/FormState.php
@@ -72,10 +72,14 @@ class FormState extends ArrayWrapper {
         if (!is_array($data)) return new FormState();
 
         if (isset($data[self::REQUEST_KEY]) && $request_class != null) {
-            $data[self::REQUEST_KEY] = new $request_class($data[self::REQUEST_KEY]);
+            $request = new $request_class($data[self::REQUEST_KEY]);
+        } else {
+            $request = null;
         }
+        if ($request != null) $data[self::REQUEST_KEY] = $request;
+
         if (isset($data[self::RESPONSE_KEY]) && $response_class != null) {
-            $data[self::RESPONSE_KEY] = new $response_class($data[self::RESPONSE_KEY]);
+            $data[self::RESPONSE_KEY] = new $response_class($request, $data[self::RESPONSE_KEY]);
         }
         return new FormState($data);
     }


### PR DESCRIPTION
`FormState` serialises requests and responses as subclasses of `ArrayWrapper`.  However, `OAuth\Response` contains protected properties which also need to be serialised into FormState in order to function properly.

Fixes #69