### PR TITLE
Enhancements to enable frontend testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ composer.lock
 node_modules/
 
 log/
+tests/frontend/*.html
+tmp/
 www/.htaccess
 www/config.php
 www/vendor/

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -46,6 +46,8 @@ class RoboFile extends \Robo\Tasks {
                     if (isset($step['variables'])) $f3->mset($step['variables']);
 
                     $result = $tpl->render($template_file);
+                } elseif (isset($step['resolve'])) {
+                    $result = $tpl->resolve($step['resolve']);
                 } elseif (isset($step['array'])) {
                     $result = [];
 

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -25,4 +25,47 @@ class RoboFile extends \Robo\Tasks {
                 ->run();
         }
     }
+    
+    public function make_frontend_tests() {
+        $tests_dir = 'tests/frontend';
+        $f3 = \Base::instance();
+        $tpl = \Template::instance();
+
+        $config = Spyc::YAMLLoad($tests_dir . '/config.yml');
+
+        foreach ($config['globals'] as $phase) {
+            $f3->mset($phase);
+        }
+
+        foreach ($config['tests'] as $output_file => $steps) {
+            $this->say($output_file);
+
+            foreach ($steps as $step) {
+                if (isset($step['template'])) {
+                    $template_file = $step['template'];
+                    if (isset($step['variables'])) $f3->mset($step['variables']);
+
+                    $result = $tpl->render($template_file);
+                } elseif (isset($step['array'])) {
+                    $result = [];
+
+                    foreach ($step['array'] as $variable => $contents) {
+                        $result[$variable] = $tpl->resolve($contents);
+                    }
+                }
+
+                if (isset($step['set'])) {
+                    $f3->set($step['set'], $result);
+                } elseif (isset($step['push'])) {
+                    if (is_array($f3->get($step['push']))) {
+                        $f3->push($step['push'], $result);
+                    } else {
+                        $f3->set($step['push'], [ $result ]);
+                    }
+                } else {
+                    $this->taskWriteToFile($tests_dir . '/' . $output_file)->text($result)->run();
+                }
+            }
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
     "scripts": {
         "test": [ "@composer install", "phpunit" ],
         "phpstan": [ "@composer install", "phpstan analyse" ],
-        "update-copyright": [ "@composer install", "robo update_copyright" ]
+        "update-copyright": [ "@composer install", "robo update_copyright" ], 
+        "make-frontend-tests": [ "@composer install", "robo make_frontend_tests" ]
     },
     "extra": {
         "branch-alias": {

--- a/tests/frontend/config.yml
+++ b/tests/frontend/config.yml
@@ -28,4 +28,36 @@ tests:
 
     - template: page.html
       variables:
+        page_class: dialog-page
         layout: auth_login.html
+
+  oauth_consent.html:
+    - template: page.html
+      variables:
+        page_class: dialog-page
+        layout: oauth_consent.html
+        application_name: Sample application
+        application_type: web
+        scope_list:
+          id: know who you are
+          profile: view your profile information (excluding e-mail and address information)
+          email: view your e-mail address
+
+  dashboard.html:
+    - array:
+        id: welcome
+        title: '{{ @intl.core.my.welcome_title | raw }}'
+        content: '{{ @intl.core.my.logged_in_as, \'test\', \'test\' | format, raw }}'
+      push: blocks
+
+    - template: page.html
+      variables:
+        layout: my_blocks.html
+
+  post.html:
+    - template: post.html
+      variables:
+        test: data-test
+        url: ''
+        params:
+          foo: bar

--- a/tests/frontend/config.yml
+++ b/tests/frontend/config.yml
@@ -1,0 +1,31 @@
+# Configuration of make_frontend_tests
+
+globals:
+  # Framework variables (1st phase)
+  - UI: www/html/
+    PREFIX: intl.
+    DEBUG: 2
+
+  # Framework variables (2nd phase)
+  - FALLBACK: en
+    LOCALES: www/locale/
+
+  # Global template variables
+  - title: Test page
+    version: test
+    base_path: /
+
+tests:
+  auth_login.html:
+    - template: auth_password.html
+      variables:
+        login_form_module: auth_password
+      set: form_content
+
+    - array:
+        content: '{{ @form_content | raw }}'
+      push: forms
+
+    - template: page.html
+      variables:
+        layout: auth_login.html

--- a/www/html/post.html
+++ b/www/html/post.html
@@ -13,7 +13,7 @@
             <div id="content-inner">            
                 <img src="{{ @base_path }}html/loading.gif" id="loading-graphic" style="display: block; margin-left: auto; margin-right: auto">
             
-                <form action="{{ @url }}" method="post" id="post-form">
+                <form action="{{ @url }}" method="post" id="post-form" {{ @@test }}>
                     <repeat group="{{ @params }}" key="{{ @name }}" value="{{ @value }}">
                         <input type="hidden" name="{{ @name }}" value= "{{ @value }}">
                     </repeat>
@@ -27,7 +27,8 @@
 
         <script type="text/javascript">
             document.getElementById("fallback").style.display = "none";
-            document.getElementById("post-form").submit();
+            if (!document.getElementById("post-form").hasAttribute("data-test"))
+                document.getElementById("post-form").submit();
             window.setTimeout(function() {
                 document.getElementById("loading-graphic").style.display = "none";
                 document.getElementById("fallback").style.display = "block";


### PR DESCRIPTION
Add composer task `make-frontend-tests`, which calls Robo taks `make_frontend_tests`, which creates a series of mockups in the `tests/frontend` directory, directly based on various templates