### PR TITLE
Fix CSRF token in AJAX requests

### DIFF
--- a/www/core/Base/MyModule.php
+++ b/www/core/Base/MyModule.php
@@ -118,7 +118,7 @@ class MyModule extends Module {
         header('Content-Type: application/json');
 
         $token = new SecurityToken();
-        if (!$this->f3->exists('GET.tk') || !$token->verify($this->f3->get('GET.tk'), 'apps')) {
+        if (!$this->f3->exists('HEADERS.X-Request-Token') || !$token->verify($this->f3->get('HEADERS.X-Request-Token'), 'apps')) {
             $this->f3->status(401);
             print json_encode([
                 'error' => 'unauthorized',
@@ -153,7 +153,7 @@ class MyModule extends Module {
         header('Content-Type: application/json');
 
         $token = new SecurityToken();
-        if (!$this->f3->exists('GET.tk') || !$token->verify($this->f3->get('GET.tk'), 'apps')) {
+        if (!$this->f3->exists('HEADERS.X-Request-Token') || !$token->verify($this->f3->get('HEADERS.X-Request-Token'), 'apps')) {
             $this->f3->status(401);
             print json_encode([
                 'error' => 'unauthorized',
@@ -226,7 +226,7 @@ class MyModule extends Module {
         header('Content-Type: application/json');
 
         $token = new SecurityToken();
-        if (!isset($delete['tk']) || !is_string($delete['tk']) || !$token->verify($delete['tk'], 'apps')) {
+        if (!$this->f3->exists('HEADERS.X-Request-Token') || !$token->verify($this->f3->get('HEADERS.X-Request-Token'), 'apps')) {
             $this->f3->status(401);
             print json_encode([
                 'error' => 'unauthorized',

--- a/www/html/my_apps.html
+++ b/www/html/my_apps.html
@@ -7,10 +7,10 @@
             tk: tk,
 
             loadApps() {
-                const params = new URLSearchParams({tk: this.tk});
-                fetch('apps?' + params, {
+                fetch('apps', {
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',
+                        'X-Request-Token': this.tk,
                         'Accept': 'application/json'
                     }
                 })
@@ -29,10 +29,10 @@
                 const currentApp = this.apps.find((app) => (app.cid == cid));
 
                 if (!currentApp.details) {
-                    const params = new URLSearchParams({tk: this.tk});
-                    fetch('apps/' + encodeURIComponent(cid) + '?' + params, {
+                    fetch('apps/' + encodeURIComponent(cid), {
                         headers: {
                             'X-Requested-With': 'XMLHttpRequest',
+                            'X-Request-Token': this.tk,
                             'Accept': 'application/json'
                         }
                     })
@@ -44,11 +44,11 @@
             },
 
             deleteApp(cid) {
-                const params = new URLSearchParams({tk: this.tk});
-                fetch('apps/' + encodeURIComponent(cid) + '?' + params, {
+                fetch('apps/' + encodeURIComponent(cid), {
                     method: 'DELETE',
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',
+                        'X-Request-Token': this.tk,
                         'Accept': 'application/json'
                     }
                 })


### PR DESCRIPTION
Currently, for AJAX requests, the CSRF token is included in the `tk` parameter.  This change moves this token to the `X-Request-Token` header.  Moving the token to the header is in line with the [OWASP Guidance].

[OWASP Guidance]: https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#javascript-guidance-for-auto-inclusion-of-csrf-tokens-as-an-ajax-request-header