### PR TITLE
Fix deprecated constructor names for PHP 8

### DIFF
--- a/www/discovery.inc.php
+++ b/www/discovery.inc.php
@@ -441,7 +441,7 @@ class XRDSParser {
      *
      * This constructor also initialises the underlying XML parser.
      */
-    function XRDSParser() {
+    function __construct() {
         $this->parser = xml_parser_create_ns();
         xml_parser_set_option($this->parser, XML_OPTION_CASE_FOLDING,0);
         xml_set_object($this->parser, $this);

--- a/www/lib/gettext/gettext.php
+++ b/www/lib/gettext/gettext.php
@@ -98,7 +98,7 @@ class gettext_reader {
    * @param object Reader the StreamReader object
    * @param boolean enable_cache Enable or disable caching of strings (default on)
    */
-  function gettext_reader($Reader, $enable_cache = true) {
+  function __construct($Reader, $enable_cache = true) {
     // If there isn't a StreamReader, turn on short circuit mode.
     if (! $Reader || isset($Reader->error) ) {
       $this->short_circuit = true;

--- a/www/lib/gettext/streams.php
+++ b/www/lib/gettext/streams.php
@@ -49,7 +49,7 @@ class StringReader {
   var $_pos;
   var $_str;
 
-  function StringReader($str='') {
+  function __construct($str='') {
     $this->_str = $str;
     $this->_pos = 0;
   }
@@ -86,7 +86,7 @@ class FileReader {
   var $_fd;
   var $_length;
 
-  function FileReader($filename) {
+  function __construct($filename) {
     if (file_exists($filename)) {
 
       $this->_length=filesize($filename);
@@ -143,7 +143,7 @@ class FileReader {
 // Preloads entire file in memory first, then creates a StringReader
 // over it (it assumes knowledge of StringReader internals)
 class CachedFileReader extends StringReader {
-  function CachedFileReader($filename) {
+  function __construct($filename) {
     if (file_exists($filename)) {
 
       $length=filesize($filename);


### PR DESCRIPTION
`/my/sites` is broken otherwise due to deprecated constructor for `XRDSParser`.