### PR TITLE
Replace strftime and gmstrftime for PHP 8.1 compatibility

### DIFF
--- a/www/config.php.dist
+++ b/www/config.php.dist
@@ -150,12 +150,12 @@ return [
     /*
      * Date and time format.
      *
-     * The date and time format specified using the strftime() syntax.
+     * The date and time format specified using the date_format() syntax.
      *
-     * See http://www.php.net/strftime for details.
+     * See https://www.php.net/manual/en/datetime.format.php for details.
      * 
      */
-    'date_time_format' => '%Y-%m-%d %H:%M:%S %Z',
+    'date_time_format' => 'Y-m-d H:i:s T',
 
     /*
      * Authentication context class reference.

--- a/www/core/Protocols/OpenID/Extensions/PAPEOpenIDExtensionModule.php
+++ b/www/core/Protocols/OpenID/Extensions/PAPEOpenIDExtensionModule.php
@@ -128,7 +128,7 @@ class PAPEOpenIDExtensionModule extends Module implements ProtocolResult {
         $response['ns.' . $alias] = self::OPENID_NS_PAPE;
         
         // We return the last time the user logged in using the login form
-        $response[$alias . '.auth_time'] = gmstrftime('%Y-%m-%dT%H:%M:%SZ', $auth->getAuthTime());
+        $response[$alias . '.auth_time'] = gmdate('Y-m-d\TH:i:s\Z', $auth->getAuthTime());
         
         // We don't comply with NIST_SP800-63
         $response[$alias . '.auth_level.ns.nist'] = self::PAPE_LEVEL_NIST800_63;

--- a/www/core/Protocols/OpenID/OpenIDModule.php
+++ b/www/core/Protocols/OpenID/OpenIDModule.php
@@ -492,7 +492,7 @@ class OpenIDModule extends Module implements ProtocolResult {
      */
     protected function createOKResponse($request) {
         $rand = new Random();
-        $nonce = gmstrftime('%Y-%m-%dT%H:%M:%SZ') . bin2hex($rand->bytes(4));
+        $nonce = gmdate('Y-m-d\TH:i:s\Z') . bin2hex($rand->bytes(4));
 
         $response = new Response($request);
         $response->setArray([

--- a/www/core/Util/DefaultLogger.php
+++ b/www/core/Util/DefaultLogger.php
@@ -90,12 +90,13 @@ class DefaultLogger extends Log implements LoggerInterface {
     function log($level, $message, array $context = []) {
         $fw = \Base::instance();
         $config = $fw->get('config');
+        $time = new \DateTimeImmutable();
 
         if (self::$log_levels[$level] > self::$log_levels[$config['log_level']]) return;
 
         if (count($context) > 0) $message .= ': ' . self::formatArray($context);
 
-        $line = sprintf('%1$s %2$s [%3$s] %4$s', strftime($config['date_time_format']), session_id(), $level, $message) . "\n";
+        $line = sprintf('%1$s %2$s [%3$s] %4$s', $time->format($config['date_time_format']), session_id(), $level, $message) . "\n";
 
         $fw->write($this->file, $line, true);
     }


### PR DESCRIPTION
`strftime` and `gmstrftime` are [deprecated][1] in PHP 8.1 onwards. This PR replaces these functions with `date` and `gmdate` respectively.

[1]: https://www.php.net/manual/en/migration81.deprecated.php