### PR TITLE
Change input tags into button tags

### DIFF
--- a/www/core/Auth/AuthModule.php
+++ b/www/core/Auth/AuthModule.php
@@ -122,7 +122,7 @@ class AuthModule extends Module {
             return;
         }
 
-        if ($this->f3->exists('POST.op') && $this->f3->get('POST.op') == $this->f3->get('intl.common.cancel')) {
+        if ($this->f3->exists('POST.op') && $this->f3->get('POST.op') == 'cancel') {
             $cancel_event = new FormSubmitEvent($form_state, 'login_form_cancel');
 
             $dispatcher->dispatch($cancel_event);

--- a/www/core/Auth/OTPAuthSchemeModule.php
+++ b/www/core/Auth/OTPAuthSchemeModule.php
@@ -67,7 +67,7 @@ class OTPAuthSchemeModule extends AuthSchemeModule {
             return;
         }
 
-        if ($this->f3->get('POST.op') == $this->f3->get('intl.common.disable')) {
+        if ($this->f3->get('POST.op') == 'disable') {
             if (($this->f3->exists('POST.tk') === false) || (!$token->verify($this->f3->get('POST.tk'), 'otp'))) {
                 $this->f3->set('message', $this->f3->get('intl.common.invalid_tk'));
                 $this->f3->mock('GET /my/dashboard');
@@ -81,7 +81,7 @@ class OTPAuthSchemeModule extends AuthSchemeModule {
             $this->f3->set('message', $this->f3->get('intl.core.auth_otp.disable_success'));
             $this->f3->mock('GET /my/dashboard');
             return;
-        } elseif ($this->f3->get('POST.op') == $this->f3->get('intl.common.verify')) {
+        } elseif ($this->f3->get('POST.op') == 'verify') {
             $params = $token->getPayload($this->f3->get('POST.otp_params'));
             $params['secret'] = base64_decode($params['secret']);
             $this->f3->set('otp_params', $this->f3->get('POST.otp_params'));
@@ -166,11 +166,11 @@ class OTPAuthSchemeModule extends AuthSchemeModule {
         if (isset($user['otp'])) {
             $html .= '<p>' . $this->f3->get('intl.core.auth_otp.otp_enabled_block') . '</p>';
             $html .= '<form action="' . $base_path . 'auth/otp" method="post" enctype="application/x-www-form-urlencoded"><input type="hidden" name="tk" value="'. $tk . '"/>';
-            $html .= '<input type="submit" name="op" value="' . $this->f3->get('intl.common.disable') . '" /></form>';
+            $html .= '<button type="submit" name="op" value="disable">' . $this->f3->get('intl.common.disable') . '</button></form>';
         } else {
             $html .= '<p>' . $this->f3->get('intl.core.auth_otp.otp_disabled_block') . '</p>';
             $html .= '<form action="' . $base_path . 'auth/otp" method="post" enctype="application/x-www-form-urlencoded"><input type="hidden" name="tk" value="'. $tk . '"/>';
-            $html .= '<input type="submit" name="op" value="' . $this->f3->get('intl.common.enable') . '" /></form>';
+            $html .= '<button type="submit" name="op" value="enable">' . $this->f3->get('intl.common.enable') . '</button></form>';
         }
         
         $event->addBlock('otp', $html, 0, [

--- a/www/core/Protocols/Connect/ConnectSessionModule.php
+++ b/www/core/Protocols/Connect/ConnectSessionModule.php
@@ -82,7 +82,7 @@ class ConnectSessionModule extends Module {
                 return;
             }
 
-            if ($this->f3->get('POST.op') == $this->f3->get('intl.common.cancel')) {
+            if ($this->f3->get('POST.op') == 'cancel') {
                 if ($form_state['connect_logout']['post_logout_redirect_uri']) {
                     $response = new Response();
                     if (isset($form_state['connect_logout']['state'])) $response['state'] = $form_state['connect_logout']['state'];

--- a/www/core/Protocols/OAuth/OAuthModule.php
+++ b/www/core/Protocols/OAuth/OAuthModule.php
@@ -724,7 +724,7 @@ class OAuthModule extends Module implements ProtocolResult {
             return;
         }
         
-        if ($this->f3->get('POST.op') == $this->f3->get('intl.common.deny')) {
+        if ($this->f3->get('POST.op') == 'deny') {
             $response->setError('access_denied')->renderRedirect();
             return;
         } else {

--- a/www/core/Protocols/OpenID/OpenIDModule.php
+++ b/www/core/Protocols/OpenID/OpenIDModule.php
@@ -849,7 +849,7 @@ class OpenIDModule extends Module implements ProtocolResult {
         $return_to = $response['return_to'];
         if ($return_to == null) $return_to = $request['openid.return_to'];
     
-        if ($this->f3->get('POST.op') == $this->f3->get('intl.common.cancel')) {
+        if ($this->f3->get('POST.op') == 'cancel') {
             $response = $this->createErrorResponse($request, false);
             if (!$return_to) $this->f3->set('message', $this->f3->get('intl.common.login_cancelled'));
         } else {

--- a/www/html/auth_login.html
+++ b/www/html/auth_login.html
@@ -8,9 +8,10 @@
         </repeat>
 
         {* @submit_button text may vary depending on auth module *}
-        <input type="submit" name="op" value="{{ @@submit_button }}" class="is-default" :disabled="isSubmitted">
+        {* value="submit" is not submitted in form data, whereas other values for the 'values' attribute would *}
+        <button type="submit" name="op" value="submit" class="is-default" :disabled="isSubmitted">{{ @@submit_button }}</button>
         <check if="{{ @@cancellable }}">
-            <input type="submit" name="op" value="{{ @intl.common.cancel }}">
+            <button type="submit" name="op" value="cancel">{{ @intl.common.cancel }}</button>
         </check>
     </form>
 </div>

--- a/www/html/auth_otp_setup.html
+++ b/www/html/auth_otp_setup.html
@@ -25,5 +25,5 @@
         <label for="edit-otp">{{ @intl.core.auth_otp.otp_label }}</label>
         <input type="text" inputmode="numeric" name="otp" id="edit-otp" size="10" value="" autocomplete="one-time-code" autocorrect="off" class="form-text otp required" />
     </div>
-    <input type="submit" name="op" id="edit-submit" value="{{ @intl.common.verify }}" class="is-default" />
+    <button type="submit" name="op" value="verify" id="edit-submit" class="is-default">{{ @intl.common.verify }}</button>
 </form>

--- a/www/html/connect_logout.html
+++ b/www/html/connect_logout.html
@@ -4,7 +4,8 @@
     
     <p>{{ @intl.core.connect.logout_consent_label | raw }}</p>
     
-    <input type="submit" name="op" id="edit-submit" value="{{ @intl.common.logout }}" class="is-default" />
-    <input type="submit" name="op" id="edit-cancel" value="{{ @intl.common.cancel }}" />
+    {* value="submit" is not submitted in form data, whereas other values for the 'values' attribute would *}
+    <button type="submit" name="op" value="submit" id="edit-submit" class="is-default">{{ @intl.common.logout }}</button>
+    <button type="submit" name="op" value="cancel" id="edit-cancel">{{ @intl.common.cancel }}</button>
 </form>
 

--- a/www/html/oauth_consent.html
+++ b/www/html/oauth_consent.html
@@ -48,6 +48,6 @@
         </label>
     </div>
     
-    <input name="op" id="edit-allow" value="{{ @intl.common.allow }}" class="is-default" type="submit">
-    <input name="op" id="edit-deny" value="{{ @intl.common.deny }}" type="submit">
+    <button type="submit" name="op" value="allow" id="edit-allow" class="is-default">{{ @intl.common.allow }}</button>
+    <button type="submit" name="op" value="deny" id="edit-deny" type="submit">{{ @intl.common.deny }}</button>
 </form>

--- a/www/html/openid_consent.html
+++ b/www/html/openid_consent.html
@@ -36,8 +36,9 @@ function confirmConsent(ev) {
                 <check if="{{ @form.weight >= 0 }}">{{ @form.content | raw }}</check>
             </repeat>
             
-            <input type="submit" name="op" id="edit-submit" value="{{ @intl.common.ok }}" class="is-default" />
-            <input type="submit" name="op" id="edit-cancel" value="{{ @intl.common.cancel }}" />
+            {* value="submit" is not submitted in form data, whereas other values for the 'values' attribute would *}
+            <button type="submit" name="op" value="submit" id="edit-submit" class="is-default">{{ @intl.common.ok }}</button>
+            <button type="submit" name="op" value="cancel" id="edit-cancel">{{ @intl.common.cancel }}</button>
         </true>
         <false>
             <div class="narrative">
@@ -48,7 +49,7 @@ function confirmConsent(ev) {
                 <p>{{ @intl.core.openid.switch_user_label, @switch_url | format, raw }}</p>
             </div>
             
-            <input type="submit" name="op" id="edit-cancel" value="{{ @intl.common.cancel }}" class="is-default">
+            <button type="submit" name="op" value="cancel" id="edit-cancel" class="is-default">{{ @intl.common.cancel }}</button>
         </false>
     </check>
 </form>


### PR DESCRIPTION
Certain `<input>` tags should be changed to `<button>` tags to enable more customisation of both the look-and-feel of the buttons, as well as for form processing.

For example, multiple submit buttons are required if more than one authentication scheme is available.