### PR TITLE
Implement secure strings

### DIFF
--- a/tests/core/Util/SecureStringTest.php
+++ b/tests/core/Util/SecureStringTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SimpleID\Util;
+
+use PHPUnit\Framework\TestCase;
+
+class SecureStringTest extends TestCase {
+    const SECURE_SECRET = 'FDaigcnJB1yyWoVtvamB6TJVNGr1R6hzeRZGsSHMaBebLKgvpdZAVRwpgfcxK2uq';
+
+    static function setUpBeforeClass(): void {
+        $_ENV['SIMPLEID_SECURE_SECRET'] = self::SECURE_SECRET;
+    }
+
+    function testSecureString() {
+        $plaintext = 'This is a test string';
+
+        $secure = SecureString::fromPlaintext($plaintext);
+
+        $this->assertNotEquals($plaintext, $secure->__toString());
+        $this->assertEquals($plaintext, $secure->toPlaintext());
+    }
+}
+?>

--- a/www/bootstrap.inc.php
+++ b/www/bootstrap.inc.php
@@ -80,6 +80,14 @@ if (!isset($config['canonical_base_path'])) {
         . ($port && $port != 80 && $port != 443 ? (':' . $port) : '') . $f3->get('BASE');
 }
 
+if (isset($config['secure_secret']) && ($config['secure_secret'] != '') && !isset($_ENV['SIMPLEID_SECURE_SECRET'])) {
+    $_ENV['SIMPLEID_SECURE_SECRET'] = $config['secure_secret'];
+    $f3->sync('ENV');
+} elseif (isset($config['secure_secret_file']) && ($config['secure_secret_file'] != '') && !isset($_ENV['SIMPLEID_SECURE_SECRET_FILE'])) {
+    $_ENV['SIMPLEID_SECURE_SECRET_FILE'] = $config['secure_secret_file'];
+    $f3->sync('ENV');
+}
+
 date_default_timezone_set(@date_default_timezone_get());
 
 $f3->mset([
@@ -142,6 +150,11 @@ if (isset($_GET['q'])) {
 if ((@ini_get('register_globals') === 1) || (@ini_get('register_globals') === '1') || (strtolower(@ini_get('register_globals')) == 'on')) {
     $f3->get('logger')->log(\Psr\Log\LogLevel::CRITICAL, 'register_globals is enabled in PHP configuration.');
     $f3->error(500, $f3->get('intl.bootstrap.register_globals', 'http://simpleid.org/docs/2/system-requirements/'));
+}
+
+if (!isset($_ENV['SIMPLEID_SECURE_SECRET']) && !isset($_ENV['SIMPLEID_SECURE_SECRET_FILE'])) {
+    $f3->get('logger')->log(\Psr\Log\LogLevel::CRITICAL, 'secure_secret or secure_secret_file not set.');
+    $f3->error(500, $f3->get('intl.bootstrap.secure_secret'));
 }
 
 if (!\SimpleID\Crypt\BigNum::loaded()) {

--- a/www/config.php.dist
+++ b/www/config.php.dist
@@ -79,6 +79,25 @@ return [
     'store_dir' => '@@STORE_DIR@@',
 
     /*
+     * Secret used to encrypt sensitive strings (such as token
+     * generation keys) that are stored locally. This should be a
+     * random string of at least 64 characters.
+     *
+     * The secret can be specified in the 'secure_secret' configuration here.
+     * Alternatively it can be set via the SIMPLEID_SECURE_SECRET environment
+     * variable (which will take precedence).
+     *
+     * Alternatively, instead of defining secure_secret, the secure_secret_file
+     * configuration (or the SIMPLEID_SECURE_SECRET_FILE environment variable)
+     * can be set to read the secret from the specified file.
+     *
+     * This secret is VERY IMPORTANT. If you lose it, data encrypted by it
+     * cannot be decrypted anymore.
+     */
+    'secure_secret' => '',
+    //'secure_secret_file' => '',
+
+    /*
      * JSON Web Key Set files.  These contain the public and private keys
      * used for JSON web tokens.  These are mandatory if you want to
      * use OpenID Connect.

--- a/www/core/Protocols/OAuth/Token.php
+++ b/www/core/Protocols/OAuth/Token.php
@@ -24,6 +24,7 @@ namespace SimpleID\Protocols\OAuth;
 use Branca\Branca;
 use SimpleID\Crypt\Random;
 use SimpleID\Store\StoreManager;
+use SimpleID\Util\SecureString;
 
 /**
  * An OAuth access or refresh token.
@@ -408,13 +409,13 @@ class Token {
     static protected function getKey() {
         $store = StoreManager::instance();
 
-        $key = $store->getSetting('oauth-token');
+        $key = SecureString::getPlaintext($store->getSetting('oauth-token'));
 
         if ($key == NULL) {
             $rand = new Random();
 
             $key = strtr(base64_encode($rand->bytes(32)), '+/', '-_');
-            $store->setSetting('oauth-token', $key);
+            $store->setSetting('oauth-token', SecureString::fromPlaintext($key));
         }
 
         return $key;

--- a/www/core/Util/Events/BaseDataCollectionEvent.php
+++ b/www/core/Util/Events/BaseDataCollectionEvent.php
@@ -83,7 +83,6 @@ class BaseDataCollectionEvent extends BaseEvent implements \GenericEventInterfac
      * @return void
      */
     public function addResult($result) {
-        /** @phpstan-ignore-next-line */
         if (($result == null) || (is_array($result) && (count($result) == 0))) return;
 
         // If recursive, result must be an array

--- a/www/core/Util/OpaqueIdentifier.php
+++ b/www/core/Util/OpaqueIdentifier.php
@@ -105,9 +105,13 @@ class OpaqueIdentifier {
             $rand = new Random();
 
             $opaque_token = $rand->bytes(16);
-            $store->setSetting('opaque-token', base64_encode($opaque_token));
+            $store->setSetting('opaque-token', SecureString::fromPlaintext($opaque_token));
         } else {
-            $opaque_token = base64_decode($opaque_token);
+            if ($opaque_token instanceof SecureString) {
+                $opaque_token = SecureString::getPlaintext($opaque_token);
+            } else {
+                $opaque_token = base64_decode($opaque_token);
+            }
         }
 
         return $opaque_token;

--- a/www/core/Util/SecureString.php
+++ b/www/core/Util/SecureString.php
@@ -79,10 +79,24 @@ final class SecureString implements \Stringable {
     }
 
     /**
-     * @param SecureString|TaggedValue|string|Stringable $value
+     * Returns the plain text value.
+     * 
+     * The plaint text value is determined based on the following rules:
+     * 
+     * 1. If $value is a SecureString, then the value is decrypted
+     * 2. If $value is a YAML !secure_string tagged value, then a SecureString is
+     *    created from the YAML value and is decrypted
+     * 3. If $value is or can be converted to a string, then the string value
+     *    is returned
+     * 4. If $value is null, then null is returned
+     * 5. Otherwise an InvalidArugmentException is raised
+     * 
+     * @param SecureString|TaggedValue|string|Stringable|null $value the value to
+     * get the plain text value
+     * @return string the plain text value, or null if $value is null
      * @throws \InvalidArgumentException
      */
-    static public function getPlaintext($value): string {
+    static public function getPlaintext($value): ?string {
         if ($value instanceof SecureString) {
             return $value->toPlaintext();
         } elseif (($value instanceof TaggedValue) && ($value->getTag() == 'secure_string')) {
@@ -91,6 +105,8 @@ final class SecureString implements \Stringable {
             return $value;
         } elseif ($value instanceof Stringable) {
             return $value->__toString();
+        } elseif ($value == null) {
+            return null;
         }
         
         throw new \InvalidArgumentException();

--- a/www/core/Util/SecureString.php
+++ b/www/core/Util/SecureString.php
@@ -21,6 +21,7 @@
 
 namespace SimpleID\Util;
 
+use \Stringable;
 use Branca\Branca;
 use Symfony\Component\Yaml\Tag\TaggedValue;
 
@@ -111,6 +112,7 @@ final class SecureString implements \Stringable {
 
     /**
      * {@inheritdoc}
+     * @param array<mixed> $data
      * @return void
      */
     public function __unserialize(array $data) {

--- a/www/core/Util/SecureString.php
+++ b/www/core/Util/SecureString.php
@@ -1,0 +1,139 @@
+<?php
+/*
+ * SimpleID
+ *
+ * Copyright (C) Kelvin Mo 2024
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the Free
+ * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+namespace SimpleID\Util;
+
+use Branca\Branca;
+use Symfony\Component\Yaml\Tag\TaggedValue;
+
+/**
+ * A secure string
+ */
+final class SecureString implements \Stringable {
+    /** @var string */
+    private $ciphertext;
+
+    /**
+     * Creates a SecureString from the specified ciphertext
+     * 
+     * @param string $ciphertext the ciphertext
+     */
+    public function __construct(string $ciphertext) {
+        $this->ciphertext = $ciphertext;
+    }
+
+    /**
+     * Creates a SecureString from a plaintext string
+     * 
+     * @param string $plaintext the plaintext to encrypt
+     * @return SecureString the secure string
+     */
+    static public function fromPlaintext(string $plaintext): SecureString {
+        $branca = new Branca(self::getKey());
+        return new SecureString($branca->encode($plaintext));
+    }
+
+    /**
+     * Returns the plaintext version of the secure string
+     * 
+     * @return string the plaintext
+     * @throws \RuntimeException if an error occurs during the decryption process
+     */
+    public function toPlaintext(): string {
+        static $plaintext = null;
+
+        if ($plaintext == null) {
+            $branca = new Branca(self::getKey());
+            $plaintext = $branca->decode($this->ciphertext);
+        }
+
+        return $plaintext;
+    }
+
+    /**
+     * Returns a YAML tagged value for serialisation into YAML
+     * 
+     * @return TaggedValue the YAML tagged value
+     */
+    public function toYamlTaggedValue(): TaggedValue {
+        return new TaggedValue('secure_string', $this->ciphertext);
+    }
+
+    /**
+     * @param SecureString|TaggedValue|string|Stringable $value
+     * @throws \InvalidArgumentException
+     */
+    static public function getPlaintext($value): string {
+        if ($value instanceof SecureString) {
+            return $value->toPlaintext();
+        } elseif (($value instanceof TaggedValue) && ($value->getTag() == 'secure_string')) {
+            return (new SecureString($value->getValue()))->toPlaintext();
+        } elseif (is_string($value)) {
+            return $value;
+        } elseif ($value instanceof Stringable) {
+            return $value->__toString();
+        }
+        
+        throw new \InvalidArgumentException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string {
+        return $this->ciphertext;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __serialize(): array {
+        return ['ciphertext' => $this->ciphertext ];
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return void
+     */
+    public function __unserialize(array $data) {
+        $this->ciphertext = $data['ciphertext'];
+    }
+
+    static private function getKey(): string {
+        /** @var string */
+        static $key = null;
+
+        if ($key == null) {
+            if (isset($_ENV['SIMPLEID_SECURE_SECRET'])) {
+                $secret = $_ENV['SIMPLEID_SECURE_SECRET'];
+            } elseif (isset($_ENV['SIMPLEID_SECURE_SECRET_FILE'])) {
+                $secret = file_get_contents($_ENV['SIMPLEID_SECURE_SECRET_FILE']);
+            } else {
+                throw new \RuntimeException('Key not found');
+            }
+            $key = hash('sha256', $secret, true);
+        }
+
+        return $key;
+    }
+}
+
+?>

--- a/www/core/Util/SecurityToken.php
+++ b/www/core/Util/SecurityToken.php
@@ -180,13 +180,13 @@ class SecurityToken {
     static private function getSiteToken() {
         $store = StoreManager::instance();
 
-        $site_token = $store->getSetting('site-token');
+        $site_token = SecureString::getPlaintext($store->getSetting('site-token'));
 
         if ($site_token == NULL) {
             $rand = new Random();
 
             $site_token = strtr(base64_encode($rand->bytes(32)), '+/', '-_');
-            $store->setSetting('site-token', $site_token);
+            $store->setSetting('site-token', SecureString::fromPlaintext($site_token));
         }
 
         return $site_token;

--- a/www/locale/en.ini
+++ b/www/locale/en.ini
@@ -67,6 +67,7 @@ footer = This email was sent to {0} by {1}.
 
 #: simpleid\www\bootstrap.inc.php
 [bootstrap]
+secure_secret = Secure secret (secure_secret or secure_secret_file) is not set in configuration file or environment variables.
 register_globals = register_globals is enabled in PHP configuration, which is not supported by SimpleID.  See the <a href="{0}">manual</a> for further information.
 extension = One or more required PHP extensions ({0}) is not loaded.  See the <a href="{1}">manual</a> for further information on system requirements.
 suhosin = suhosin.get.max_value_length is less than 1024, which will lead to problems. See the <a href="{0}">manual</a> for further information on system requirements.


### PR DESCRIPTION
Currently a number of keys used to generate tokens are stored as plain text as a SimpleID "setting".  This creates difficulties as these keys cannot be managed by secrets management systems, such as Hardware Security Modules.

The solution to this is to encrypt these keys using a single master key.  The master key can then be specified in a configuration file, an environment variable or a separate file in the filesystem, the latter two of which can be managed by external security modules.