### PR TITLE
Fix `undefined array key 1` error when parsing query string.

### DIFF
--- a/www/bootstrap.inc.php
+++ b/www/bootstrap.inc.php
@@ -264,8 +264,10 @@ function parse_http_query($query) {
     $pairs = explode('&', $query);
     
     foreach ($pairs as $pair) {
-        list ($key, $value) = explode('=', $pair, 2);
-        $data[$key] = urldecode($value);
+        if (!empty($pair)) {
+            list ($key, $value) = explode('=', $pair, 2);
+            $data[$key] = urldecode($value);
+        }
     }
 
     return $data;


### PR DESCRIPTION
This fixes this backtrace: 

```
NOTICE: PHP message: Undefined array key 1
NOTICE: PHP message: [bootstrap.inc.php:267]
NOTICE: PHP message: [bootstrap.inc.php:267] Base->{closure}()
NOTICE: PHP message: [bootstrap.inc.php:205] parse_http_query()
NOTICE: PHP message: [bootstrap.inc.php:141] fix_http_request()
NOTICE: PHP message: [index.php:23] require_once()
```
