### PR TITLE
Remove `prefs.oauth.prompt_none` from user preferences

### DIFF
--- a/tests/core/Models/UserTest.php
+++ b/tests/core/Models/UserTest.php
@@ -21,7 +21,6 @@ class UserTest extends TestCase {
 
         // Set up $user_cfg->clients
         $user_cfg->clients['test_cid'] = [
-            'oauth' => [ 'prompt_none' => true ],
             'store_id' => 'test_cid',
             'consents' => [ 'oauth' => ['openid'] ]
         ];
@@ -45,7 +44,7 @@ class UserTest extends TestCase {
 
         $user->loadData($user_cfg);
 
-        $this->assertTrue($user->clients['test_cid']['oauth']['prompt_none']);
+        $this->assertContains('openid', $user->clients['test_cid']['consents']['oauth']);
 
         $activities = $user->getActivities();
         $this->assertEquals('app', $activities['test_cid']['type']);

--- a/www/core/Protocols/OAuth/OAuthModule.php
+++ b/www/core/Protocols/OAuth/OAuthModule.php
@@ -759,10 +759,6 @@ class OAuthModule extends Module implements ProtocolResult {
             $prefs['last_time'] = $now;
             $prefs['consents'] = array_merge($prefs['consents'], $consents);
 
-            if ($this->f3->exists('POST.prefs.oauth.prompt_none') && ($this->f3->get('POST.prefs.oauth.prompt_none') == 'true')) {
-                $prefs['oauth']['prompt_none'] = true;
-            }
-                
             $user->clients[$cid] = $prefs;
             $store->saveUser($user);
         }

--- a/www/html/oauth_consent.html
+++ b/www/html/oauth_consent.html
@@ -40,14 +40,7 @@
         </div>
     </div>
     </check>
-    
-    <div class="form-item">
-        <label class="option">
-            <input class="{{ @@client_dynamic }}" type="checkbox" name="prefs[oauth][prompt_none]" value="true">
-            {{ @intl.common.consent.consent_label, @application_name | format, raw }}
-        </label>
-    </div>
-    
+        
     <button type="submit" name="op" value="allow" id="edit-allow" class="is-default">{{ @intl.common.allow }}</button>
     <button type="submit" name="op" value="deny" id="edit-deny" type="submit">{{ @intl.common.deny }}</button>
 </form>


### PR DESCRIPTION
OAuth user preferences (`$user->clients[$cid]`) contains a key `prefs.oauth.prompt_none` that is never used.  This PR removes the redundant preference and its associated UI.