### PR TITLE
Ignore empty Authorization header

### DIFF
--- a/www/core/Protocols/OAuth/Request.php
+++ b/www/core/Protocols/OAuth/Request.php
@@ -128,7 +128,7 @@ class Request extends ArrayWrapper {
      * exists
      */
     public function getAuthorizationHeader($parse_credentials = false) {
-        if (!$this->hasHeader('Authorization')) return null;
+        if (!$this->hasHeader('Authorization') || $this->getHeader('Authorization') == '') return null;
 
         $results = [];
 


### PR DESCRIPTION
When evaluating SimpleID I ran into the problem that sometimes an empty Authorization header was sent by one of the applications. In this case the `preg_split` following in the code will return an array with only a single entry. [Destructuring this](https://github.com/simpleid/simpleid/blob/d558d63d724a3a516d0d3d0dee6a6fc05d93ebab/www/core/Protocols/OAuth/Request.php#L138) into two elements will result in an error. The additional check in this PR avoids running into this error.

Currently, a single "word" as Authorization header value would also result in an error as `preg_split` would produce an array containing a single value as a result.