### PR TITLE
Require `intl` PHP extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,12 @@
 {
     "name": "PHP + Node",
-    "image": "mcr.microsoft.com/devcontainers/php:8.1-bullseye",
+    // See https://hub.docker.com/r/microsoft/devcontainers for details
+    "image": "mcr.microsoft.com/devcontainers/php:8.2-bullseye",
 
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
         "ghcr.io/devcontainers/features/node:1": {
-          "version": "20"
+          "version": "22"
         }
     },
 
@@ -38,7 +39,7 @@
     },
 
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "sudo curl -sSLf -o /usr/local/bin/install-php-extensions https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions && sudo chmod +x /usr/local/bin/install-php-extensions && sudo PHP_INI_DIR=/usr/local/etc/php install-php-extensions bcmath gmp xdebug && composer install && npm install"
+    "postCreateCommand": "sudo curl -sSLf -o /usr/local/bin/install-php-extensions https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions && sudo chmod +x /usr/local/bin/install-php-extensions && sudo PHP_INI_DIR=/usr/local/etc/php install-php-extensions bcmath gmp xdebug intl && composer install && npm install"
 
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     // "remoteUser": "root"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: openssl, hash, gmp, xml
+          extensions: openssl, hash, gmp, xml, intl
           tools: composer
 
       - name: Get Composer cache directory

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "ext-openssl": "*",
         "ext-hash": "*",
         "ext-sodium": "*",
+        "ext-intl": "*",
         "kelvinmo/simplexrd": "^3.0",
         "kelvinmo/simplejwt": "^1.0",
         "bcosca/fatfree-core": "^3.8",


### PR DESCRIPTION
Fat-Free Framework now requires the `intl` PHP extension to be enabled for PHP 8.1 and greater (see, for example https://github.com/f3-factory/fatfree-core/blob/4c94e7d57be4cd3b63c13ee99f0177c4f8b9281a/base.php#L1140).

This PR includes `ext-intl` in composer.json and updates dev tooling to load the extension.