### PR TITLE
Refactor js code to use Alpine.js v3 API

### DIFF
--- a/www/html/auth_webauthn.html
+++ b/www/html/auth_webauthn.html
@@ -1,7 +1,7 @@
 <script src="{{ @base_path }}html/assets/webauthn.js" type="text/javascript"></script>
 <script type="text/javascript">
-    function getCredentialApp(url, tk, baseRequestOptions) {
-        return {
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('getCredentialApp', (url, tk, baseRequestOptions) => ({
             supported: document.isPublicKeyCredentialSupported(),
             challenge: '',
             nonce: '',
@@ -46,8 +46,8 @@
                     console.error(e.name);
                 }
             }
-        }
-    }
+        }));
+    });
 </script>
 
 <div class="narrative">

--- a/www/html/auth_webauthn_dashboard.html
+++ b/www/html/auth_webauthn_dashboard.html
@@ -7,7 +7,7 @@
             url: url,
             tk: tk,
 
-            loadCredentials() {
+            init() {
                 fetch(this.url + '/credentials', {
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',
@@ -46,7 +46,7 @@
     }
 </script>
 
-<div x-data="webAuthnCredentialsApp({{ @base_path . 'auth/webauthn' | js, raw }}, {{ @webauthn_tk | js, raw }})" x-init="loadCredentials">
+<div x-data="webAuthnCredentialsApp({{ @base_path . 'auth/webauthn' | js, raw }}, {{ @webauthn_tk | js, raw }})">
     <div class="message" x-cloak x-show="message"><p x-html="message"></p></div>
 
     <p>{{ @intl.core.auth_webauthn.about_security_keys }}</p>

--- a/www/html/auth_webauthn_dashboard.html
+++ b/www/html/auth_webauthn_dashboard.html
@@ -1,6 +1,6 @@
 <script type="text/javascript">
-    function webAuthnCredentialsApp(url, tk) {
-        return {
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('webAuthnCredentialsApp', (url, tk) => ({
             credentials: [],
             message: '',
             isLoading: true,
@@ -42,8 +42,8 @@
                     }
                 })
             }
-        }
-    }
+        }));
+    });
 </script>
 
 <div x-data="webAuthnCredentialsApp({{ @base_path . 'auth/webauthn' | js, raw }}, {{ @webauthn_tk | js, raw }})">

--- a/www/html/auth_webauthn_setup.html
+++ b/www/html/auth_webauthn_setup.html
@@ -1,7 +1,7 @@
 <script src="{{ @base_path }}html/assets/webauthn.js" type="text/javascript"></script>
 <script type="text/javascript">
-    function createCredentialApp(url, tk, baseCreateOptions) {
-        return {
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('createCredentialApp', (url, tk, baseCreateOptions) => ({
             supported: document.isPublicKeyCredentialSupported(),
             hasLocalAuthenticator: await document.hasLocalAuthenticator(),
             challenge: '',
@@ -49,8 +49,8 @@
                     console.error(e);
                 }
             }
-        };
-    }
+        }));
+    });
 </script>
 <div class="narrative">
     <p>{{ @intl.core.auth_webauthn.about_security_keys }}</p>

--- a/www/html/connect_check_session.html
+++ b/www/html/connect_check_session.html
@@ -8,8 +8,8 @@
     <body>
         <script src="{{ @base_path }}html/assets/default.js" type="text/javascript"></script>
         <script type="text/javascript">
-            function checkSessionApp(options) {
-                return {
+            document.addEventListener('alpine:init', () => {
+                Alpine.data('checkSessionApp', (options) => ({
                     cookieName: options.cookieName,
 
                     checkSession($ev) {
@@ -50,8 +50,8 @@
                             ev.source.postMessage((result) ? 'unchanged' : 'changed', ev.origin);
                         });
                     }
-                }
-            }
+                }));
+            });
         </script>
 
         <div x-data="checkSessionApp({ cookieName: '{{ @cookie_name }}'})" @message.window="checkSession"></div>

--- a/www/html/my_apps.html
+++ b/www/html/my_apps.html
@@ -6,7 +6,7 @@
             isLoading: true,
             tk: tk,
 
-            loadApps() {
+            init() {
                 fetch('apps', {
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',
@@ -47,7 +47,7 @@
     }
 </script>
 
-<div x-data="appsApp('{{ @tk }}')" x-init="loadApps">
+<div x-data="appsApp('{{ @tk }}')">
     <div class="message" x-cloak x-show="message"><p x-html="message"></p></div>
 
     <table id="apps">

--- a/www/html/my_apps.html
+++ b/www/html/my_apps.html
@@ -1,6 +1,6 @@
 <script type="text/javascript">
-    function appsApp(tk) {
-        return {
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('appsApp', (tk) => ({
             apps: [],
             message: '',
             isLoading: true,
@@ -43,8 +43,8 @@
                     }
                 })
             }
-        }
-    }
+        }));
+    });
 </script>
 
 <div x-data="appsApp('{{ @tk }}')">

--- a/www/html/openid_profile.html
+++ b/www/html/openid_profile.html
@@ -1,6 +1,6 @@
 <script>
-function openIdDiscoveryApp() {
-    return {
+document.addEventListener('alpine:init', () => {
+    Alpine.data('openIdDiscoveryApp', () => ({
         templates: {
             openid1: '&lt;link rel="openid.server" href="{{ rtrim(@config.canonical_base_path, '/') }}/"&gt;',
             openid2: '&lt;link rel="openid2.provider" href="{{ rtrim(@config.canonical_base_path, '/') }}/"&gt;',
@@ -27,11 +27,11 @@ function openIdDiscoveryApp() {
             
             return code;
         }
-    }
-}
+    }));
+});
 </script>
 
-<div x-data="openIdDiscoveryApp()">
+<div x-data="openIdDiscoveryApp">
     <h3>{{ @intl.core.openid.link_tags_label }}</h3>
             
     <div>

--- a/www/upgrade/upgrade_apply.html
+++ b/www/upgrade/upgrade_apply.html
@@ -5,7 +5,7 @@
             error: '',
             step: initStep,
 
-            upgradeApply() {
+            init() {
                 const params = new URLSearchParams({ step: this.step });
                 fetch('step', {
                     method: 'POST',
@@ -37,7 +37,7 @@
     }
 </script>
 
-<div x-data="upgradeApp('{{ @step }}')" x-init="upgradeApply" class="narrative">
+<div x-data="upgradeApp('{{ @step }}')" class="narrative">
     <p>{{ @intl.upgrade.applying_upgrade }} <span x-html="progress"></span></p>
 
     <div class="upgrade--error" x-cloak x-show="error">

--- a/www/upgrade/upgrade_apply.html
+++ b/www/upgrade/upgrade_apply.html
@@ -1,6 +1,6 @@
 <script type="text/javascript">
-    function upgradeApp(initStep) {
-        return {
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('upgradeApp', (initStep) => ({
             progress: '',
             error: '',
             step: initStep,
@@ -33,8 +33,8 @@
                 })
                 .catch(err => this.error = err.message);
             }
-        };
-    }
+        }));
+    });
 </script>
 
 <div x-data="upgradeApp('{{ @step }}')" class="narrative">


### PR DESCRIPTION
Existing interactive javascript code in SimpleID is written using the Alpine.js v2 API.  While these still work in v3, some of them are deprecated in future versions of Alpine.js.  This PR refactors these [breaking changes](https://alpinejs.dev/upgrade-guide) to use the v3 API.