### PR TITLE
Reset autologin on credential change

### DIFF
--- a/www/core/Auth/RememberMeAuthSchemeModule.php
+++ b/www/core/Auth/RememberMeAuthSchemeModule.php
@@ -23,6 +23,7 @@
 namespace SimpleID\Auth;
 
 use Psr\Log\LogLevel;
+use SimpleID\Auth\CredentialEvent;
 use SimpleID\Auth\NonInteractiveAuthEvent;
 use SimpleID\Crypt\Random;
 use SimpleID\Crypt\SecurityToken;
@@ -150,6 +151,15 @@ class RememberMeAuthSchemeModule extends AuthSchemeModule {
      */
     public function onLogoutEvent(LogoutEvent $event) {
         $this->removeCookie();
+    }
+
+    /**
+     * @return void
+     */
+    public function onCredentialEvent(CredentialEvent $event) {
+        if ($event->getAuthModuleName() != self::class) {
+            $this->removeCookie();
+        }
     }
 
     /**


### PR DESCRIPTION
Updates `RememberMeAuthSchemeModule` so that if a CredentialEvent occurs, then the autologin cookie is deleted.